### PR TITLE
Add unavailability notice to the site for the pile

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -155,6 +155,10 @@ h2.text-title {
   text-decoration: underline;
 }
 
+#unavailable-notice {
+  color: red;
+}
+
 .text-content.centralize-text {
   text-align: center;
 }

--- a/index.html
+++ b/index.html
@@ -63,10 +63,11 @@
           </div>
           <div class="content-box">
             <h2 class="text-title">Download</h2>
+            <p class="text-content" id="unavailable-notice">The Pile is currently unavailable for download. Information below is left in place to minimize disruption. We apologize for the inconvenience.</p>
             <p class="text-content">The Pile is hosted by <a href="https://the-eye.eu/">the Eye</a>.</p>
             <div class="buton-container">
               <div>
-                <a class="button unfilled" href="https://the-eye.eu/public/AI/pile/"
+                <a class="button unfilled" <!-- href="https://the-eye.eu/public/AI/pile/" -->
                   >Download Pile
               </a>
               </div>


### PR DESCRIPTION
Might slightly mitigate people asking why and if the Eye is down, both in EAI and from The Eye.

Haven't actually tested this but it's html and I would suspect it's clean.